### PR TITLE
no longer swallow iterator errors

### DIFF
--- a/moredis/config.go
+++ b/moredis/config.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"text/template"
 
-	"gopkg.in/v2/yaml"
+	"gopkg.in/yaml.v2"
 )
 
 // Config is the config for the cache

--- a/moredis/dbs.go
+++ b/moredis/dbs.go
@@ -5,10 +5,9 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/Clever/moredis/logger"
 	"github.com/garyburd/redigo/redis"
 	"gopkg.in/mgo.v2"
-
-	"github.com/Clever/moredis/logger"
 )
 
 // SetupDbs takes connection parameters for redis and mongo and returns active sessions.
@@ -71,6 +70,7 @@ func resolveRedis(address string) (string, error) {
 // The main purpose of breaking this out into an interface is for ease of mocking in tests.
 type MongoIter interface {
 	Next(result interface{}) bool
+	Err() error
 	Close() error
 }
 

--- a/moredis/moredis.go
+++ b/moredis/moredis.go
@@ -148,6 +148,7 @@ func ProcessQuery(writer RedisWriter, iter MongoIter, maps []MapConfig) error {
 	}
 	if err := iter.Err(); err != nil {
 		logger.Error("Iteration error", err)
+		return err
 	}
 	if err := iter.Close(); err != nil {
 		logger.Error("Iter.Close() error", err)

--- a/moredis/moredis.go
+++ b/moredis/moredis.go
@@ -146,8 +146,11 @@ func ProcessQuery(writer RedisWriter, iter MongoIter, maps []MapConfig) error {
 		}
 		processed++
 	}
+	if err := iter.Err(); err != nil {
+		logger.Error("Iteration error", err)
+	}
 	if err := iter.Close(); err != nil {
-		logger.Error("Iterator error", err)
+		logger.Error("Iter.Close() error", err)
 		return err
 	}
 	if err := writer.Flush(); err != nil {

--- a/moredis/moredis_test.go
+++ b/moredis/moredis_test.go
@@ -37,6 +37,10 @@ func (m *MockIter) Close() error {
 	return nil
 }
 
+func (m *MockIter) Err() error {
+	return nil
+}
+
 func TestProcessQuery(t *testing.T) {
 	iter := NewMockIter([]bson.M{{"test": "1", "val": "expected"}})
 


### PR DESCRIPTION
We were skipping checking for iterator errors after iterating (I mistakingly thought Close() returned those errors)