### PR TITLE
Oauth 220 field determinstic order

### DIFF
--- a/moredis/config.go
+++ b/moredis/config.go
@@ -18,6 +18,7 @@ type CollectionConfig struct {
 	Collection string      `yaml:"collection"`
 	Query      string      `yaml:"query"`
 	Projection string      `yaml:"projection"`
+	Sort       string      `yaml:"sort"`
 	Maps       []MapConfig `yaml:"maps"`
 }
 

--- a/moredis/moredis.go
+++ b/moredis/moredis.go
@@ -73,7 +73,8 @@ func processCollections(cacheConfig Config, params Params, mongoDb *mgo.Database
 				logger.Error("Error applying sort template", err)
 			}
 			for k := range sort {
-				if sort[k].(int) == -1 {
+				fmt.Printf("here is your value", sort[k])
+				if int(sort[k].(float64)) == -1 {
 					partialQuery = partialQuery.Sort(k)
 					break // assume only one specified
 				} else {


### PR DESCRIPTION
Why: needed a way to sort mongo output data for hashing consistency for duplicate fields
What: added a sort field so that we could sort the output based on a field
Test: ran locally with real data set and confirmed that multiple runs (with data update) maintains the same mapping on duplicate fields (consistency not promised if the change is within the duplicate fields)
NOTE: might timeout on large query results with low hardware setting